### PR TITLE
Add support for 'video/ogg' files to thumbnailer

### DIFF
--- a/mate-desktop-environment/debian/mate-ffmpegthumbnailer.thumbnailer
+++ b/mate-desktop-environment/debian/mate-ffmpegthumbnailer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=ffmpegthumbnailer
 Exec=ffmpegthumbnailer -i %i -o %o -s %s -f
-MimeType=video/jpeg;video/mp4;video/mpeg;video/quicktime;video/x-ms-asf;video/x-ms-wm;video/x-ms-wmv;video/x-msvideo;video/x-flv;video/x-matroska;video/mp2t;video/3gpp;video/webm;video/x-ogm+ogg;
+MimeType=video/ogg;video/jpeg;video/mp4;video/mpeg;video/quicktime;video/x-ms-asf;video/x-ms-wm;video/x-ms-wmv;video/x-msvideo;video/x-flv;video/x-matroska;video/mp2t;video/3gpp;video/webm;video/x-ogm+ogg;


### PR DESCRIPTION
Fixed problem: still missing thumbnailer support for some video files with 'video/ogg' mime type, for example *.ogv files.