### PR TITLE
update mate-polkit installation file

### DIFF
--- a/mate-polkit/debian/mate-polkit.install
+++ b/mate-polkit/debian/mate-polkit.install
@@ -1,1 +1,1 @@
-usr/lib/*/polkit-mate/
+usr/lib/*/polkit-mate-authentication-agent-1


### PR DESCRIPTION
as reported here https://github.com/mate-desktop/debian-packages/issues/94
builds seem to fail due to a wrongly included folder, and it seems that this fix resolves the problem