### PR TITLE
Added missing directory for dh_install

### DIFF
--- a/libmateweather/debian/libmateweather-common.install
+++ b/libmateweather/debian/libmateweather-common.install
@@ -2,3 +2,4 @@ usr/share/glib-2.0/
 usr/share/icons/
 usr/share/libmateweather/
 usr/share/locale/
+usr/share/gtk-doc/


### PR DESCRIPTION
When tried to build the Debian package for libmateweather, it failed with messages like:

`dh_install: usr/share/gtk-doc/html/libmateweather/home.png exists in debian/tmp but is not installed to anywhere`

This fix solves the problem.
Greets.